### PR TITLE
Chore: Switch to running dependabot once a week

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     automerged_updates:
       - match:
           dependency_type: "development"


### PR DESCRIPTION
Note: This PR and related ones for our other projects set the update schedule to `weekly`. The specific day and time of day the update occurs has already been configured via our dependabot dashboard to be Sunday night at midnight PST.